### PR TITLE
replace usage of color package with tinycolor2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     }
   },
   "dependencies": {
-    "color": "^2.0.0",
-    "node-milight-promise": "^0.2.31"
+    "node-milight-promise": "^0.2.31",
+    "tinycolor2": "^1.4.1"
   }
 }


### PR DESCRIPTION
This is to get a wider coverage of color space conversions. This helpful for users which use nodes producing hsv color values, for example, which are not supported by the "color" package. See also https://github.com/mwittig/node-milight-promise/issues/21#issuecomment-319191591